### PR TITLE
Added PickitOverrides and MuleloggerOverrides

### DIFF
--- a/libs/SoloLeveling/Functions/Globals.js
+++ b/libs/SoloLeveling/Functions/Globals.js
@@ -10,6 +10,7 @@ if (!isIncluded("OOG.js")) {
 //Configurable Settings for Overlay and Performance tracking
 const shouldLog = false;	//Default should be false for people who aren't interested in performance statistics
 const useOverlay = false;	//Default should be false for people who aren't interested in having the overlay
+const logEquipped = false;	//Default should be false for people who arne't interested in having equipped items viewable from D2Bot# charviewer tab
 
 // general settings
 var finalBuild = DataFile.getStats().finalBuild;
@@ -1204,6 +1205,7 @@ var tierscore = function (item) {
 		DEF: 0.05, // defense
 		ICB: 2, // increased chance to block
 		BELTSLOTS: 1.25, //belt potion storage
+		MF: 1, //Magic Find
 		// base stats
 		HP:	1.75,
 		MANA: 0.8,
@@ -1300,11 +1302,20 @@ var tierscore = function (item) {
 			beltRating = Storage.BeltSize() * 4 * generalWeights.BELTSLOTS; // rows * columns * weight
 		}
 
+		//Magic Find
+		let mfRating = 0,
+			needMF = me.getStat(80) < 50;
+
+		if(needMF) {
+			mfRating = item.getStatEx(80) * generalWeights.MF;
+		}
+
 		//start generalRating
 		let generalRating = 0;
 		generalRating += cbfRating; // add cannot be frozen
 		generalRating += frwRating; // add faster run walk
 		generalRating += beltRating; // add belt slots
+		generalRating += mfRating; // add magic find
 		generalRating += item.getStatEx(99) * generalWeights.FHR; // add faster hit recovery
 		generalRating += item.getStatEx(31) * generalWeights.DEF; //	add Defense
 		generalRating += (item.getStatEx(20) + item.getStatEx(102)) * generalWeights.ICB; //add increased chance to block

--- a/libs/SoloLeveling/Functions/MuleloggerOverrides.js
+++ b/libs/SoloLeveling/Functions/MuleloggerOverrides.js
@@ -1,0 +1,206 @@
+/*
+*	@filename	MuleloggerOverrides.js
+*	@author		theBguy
+*	@desc		Mulelogger.js fixes for QOL
+*/
+
+if (!isIncluded("MuleLogger.js")) {
+	include("MuleLogger.js");
+}
+
+if (!isIncluded("SoloLeveling/Functions/NTIPOverrides.js")) {
+	include("SoloLeveling/Functions/NTIPOverrides.js");
+};
+
+if (!isIncluded("SoloLeveling/Functions/MiscOverrides.js")) { 
+	include("SoloLeveling/Functions/MiscOverrides.js"); 
+};
+
+MuleLogger.getItemDesc = function (unit, logIlvl) {
+	var i, desc, index,
+		stringColor = "";
+
+	if (logIlvl === undefined) {
+		logIlvl = this.LogItemLevel;
+	}
+
+	try{
+		//Try a few times, sometimes it fails
+		for(let i = 0; i < 5; i++) {
+			desc = unit.description.split("\n");
+
+			if(desc) {
+				break;
+			}
+
+			delay(250 + me.ping*2);
+		}
+	}catch(e) {
+		print("Failed to get description of " + unit.fname);	//This isn't a fatal error just log and move on
+
+		return false;
+	}
+
+	// Lines are normally in reverse. Add color tags if needed and reverse order.
+	for (i = 0; i < desc.length; i += 1) {
+		if (desc[i].indexOf(getLocaleString(3331)) > -1) { // Remove sell value
+			desc.splice(i, 1);
+
+			i -= 1;
+		} else {
+			// Add color info
+			if (!desc[i].match(/^(y|ÿ)c/)) {
+				desc[i] = stringColor + desc[i];
+			}
+
+			// Find and store new color info
+			index = desc[i].lastIndexOf("ÿc");
+
+			if (index > -1) {
+				stringColor = desc[i].substring(index, index + "ÿ".length + 2);
+			}
+		}
+
+		desc[i] = desc[i].replace(/(y|ÿ)c([0-9!"+<:;.*])/g, "\\xffc$2").replace("ÿ", "\\xff", "g");
+	}
+
+	if (logIlvl && desc[desc.length - 1]) {
+		desc[desc.length - 1] = desc[desc.length - 1].trim() + " (" + unit.ilvl + ")";
+	}
+
+	desc = desc.reverse().join("\\n");
+
+	return desc;
+}
+
+MuleLogger.logEquippedItems = function () {
+	while (!me.gameReady) {
+		delay(100);
+	}
+	
+	var i, folder, string, parsedItem,
+		items = me.getItems(),
+		realm = me.realm || "Single Player",
+		merc, charClass,
+		finalString = "";
+
+	if (!FileTools.exists("mules/" + realm)) {
+		folder = dopen("mules");
+
+		folder.create(realm);
+	}
+
+	if (!FileTools.exists("mules/" + realm + "/" + "SoloLeveling")) {
+		folder = dopen("mules/" + realm);
+
+		folder.create("SoloLeveling");
+	}
+
+	if (!FileTools.exists("mules/" + realm + "/" + "SoloLeveling/" + me.account)) {
+		folder = dopen("mules/" + realm + "/SoloLeveling");
+
+		folder.create(me.account);
+	}
+
+	if (!items || !items.length) {
+		return;
+	}
+
+	function itemSort(a, b) {
+		return b.itemType - a.itemType;
+	}
+
+	items.sort(itemSort);
+
+	for (i = 0; i < items.length; i += 1) {
+		if ((items[i].mode === 1 && (items[i].quality !== 2 || !Misc.skipItem(items[i].classid))) || (items[i].mode === 0 && items[i].itemType === 74) ) {
+			parsedItem = this.logItem(items[i], true);
+
+			// Always put name on Char Viewer items
+			if (!parsedItem.header) {
+				parsedItem.header = (me.account || "Single Player") + " / " + me.name;
+			}
+
+			// Remove itemtype_ prefix from the name
+			parsedItem.title = parsedItem.title.substr(parsedItem.title.indexOf("_") + 1);
+
+			if (items[i].mode === 1 && (items[i].location !== 11 && items[i].location !== 12)) {
+				parsedItem.title += " (equipped)";
+			}
+
+			if(NTIP.GetTier(items[i]) > 0) {
+				parsedItem.header += "\n(Tier: " + NTIP.GetTier(items[i]) + ")";
+			}
+
+			if (items[i].mode === 1 && (items[i].location === 11 || items[i].location === 12)) {
+				parsedItem.title += " (secondary equipped)";
+			}
+
+			if (items[i].mode === 0) {
+				parsedItem.title += " (in stash)";
+			}
+
+			string = JSON.stringify(parsedItem);
+			finalString += (string + "\n");
+		}
+		
+	}
+
+	if (Config.UseMerc) {
+		for (i = 0; i < 3; i += 1) {
+			merc = me.getMerc();
+
+			if (merc) {
+				break;
+			}
+
+			delay(50);
+		}
+
+		if (merc) {
+			items = merc.getItems();
+
+			for (i = 0; i < items.length; i += 1) {
+				parsedItem = this.logItem(items[i]);
+				parsedItem.title += " (merc)";
+
+				if(NTIP.GetMercTier(items[i]) > 0){
+					parsedItem.header += "(MercTier: " + NTIP.GetMercTier(items[i]) + ")\n";
+				}
+
+				string = JSON.stringify(parsedItem);
+				finalString += (string + "\n");
+			}
+		}
+
+	}
+
+	switch(me.classid) {
+	case 0:
+		charClass = " Amazon";
+		break;
+	case 1:
+		charClass = " Sorceress";
+		break;
+	case 2:
+		charClass = " Necromancer";
+		break;
+	case 3:
+		charClass = " Paladin";
+		break;
+	case 4:
+		charClass = " Barbarian";
+		break;
+	case 5:
+		charClass = " Druid";
+		break;
+	case 6:
+		charClass = " Assassin";
+		break;
+	}
+
+	// hcl = hardcore class ladder
+	// sen = softcore expan nonladder
+	FileTools.writeText("mules/" + realm + "/" + "SoloLeveling/" + me.account + "/" + me.name + charClass + "." + ( me.playertype ? "h" : "s" ) + (me.gametype ? "e" : "c" ) + ( me.ladder > 0 ? "l" : "n" ) + ".txt", finalString);
+	print("Item logging done.");
+};

--- a/libs/SoloLeveling/Functions/NTIPOverrides.js
+++ b/libs/SoloLeveling/Functions/NTIPOverrides.js
@@ -9,6 +9,7 @@ if (!isIncluded("NTItemParser.dbl")) {
 }
 
 var NTIP_CheckListNoTier = [];
+var NTIP_QuestItems = [87,88,89,90,91,92,173,174,521,524,525,545,546,547,548,549,552,553,554,555];
 
 NTIP.addLine = function (itemString) {
 	let info = {

--- a/libs/SoloLeveling/Functions/PickitOverrides.js
+++ b/libs/SoloLeveling/Functions/PickitOverrides.js
@@ -1,0 +1,343 @@
+/*
+*	@filename	PickitOverrides.js
+*	@author		theBGuy
+*	@desc		Pickit.js fixes to improve functionality
+*/
+
+if (!isIncluded("common/Pickit.js")) {
+	include("common/Pickit.js");
+}
+
+if (!isIncluded("SoloLeveling/Functions/NTIPOverrides.js")) {
+	include("SoloLeveling/Functions/NTIPOverrides.js"); 
+};
+
+if (!isIncluded("SoloLeveling/Functions/MiscOverrides.js")) {
+	include("SoloLeveling/Functions/MiscOverrides.js"); 
+};
+
+if (!isIncluded("bots/SoloLeveling.js")) {
+	include("bots/SoloLeveling.js");
+}
+
+Pickit.checkItem = function (unit) {
+	var rval = NTIP.CheckItem(unit, false, true);
+
+	if ((unit.classid === 617 || unit.classid === 618) && Town.repairIngredientCheck(unit)) {
+		return {
+			result: 6,
+			line: null
+		};
+	}
+
+	if (CraftingSystem.checkItem(unit)) {
+		return {
+			result: 5,
+			line: null
+		};
+	}
+
+	if (Cubing.checkItem(unit)) {
+		return {
+			result: 2,
+			line: null
+		};
+	}
+
+	if (Runewords.checkItem(unit)) {
+		return {
+			result: 3,
+			line: null
+		};
+	}
+
+	if ((NTIP.GetMercTier(unit) > 0 || NTIP.GetTier(unit) > 0) && !unit.getFlag(0x10)) {
+		return {
+			result: -1,
+			line: null
+		};			
+	}
+
+	if ((NTIP.GetMercTier(unit) > 0 || NTIP.GetTier(unit) > 0) && unit.getFlag(0x10)) {
+		if (Item.autoEquipCheck(unit) && NTIP.GetTier(unit) > 1) {
+			return {
+				result: 1,
+				line: "Equip char tier: " + NTIP.GetTier(unit)
+			};
+		}
+		if (Item.autoEquipCheckMerc(unit)) {
+			return {
+				result: 1,
+				line: "Equip merc tier: " + NTIP.GetMercTier(unit)
+			};
+		}
+		//print("\xFFc4Checking " + Pickit.itemColor(unit) + unit.name + " \xFFc0 vs no Tier pickit.");
+		return NTIP.CheckItem(unit, NTIP_CheckListNoTier, true);
+	}
+
+	// If total gold is less than 10k pick up anything worth 10 gold per
+	// square to sell in town.
+	if (rval.result === 0 && !getBaseStat("items", unit.classid, "quest") && Town.ignoredItemTypes.indexOf(unit.itemType) === -1 && unit.itemType !== 39 && (unit.location === 3 || me.gold < Config.LowGold)) {
+		// Gold doesn't take up room, just pick it up
+		if (unit.classid === 523) {
+			return {
+				result: 4,
+				line: null
+			};
+		}
+
+		if ((unit.getItemCost(1) / (unit.sizex * unit.sizey) >= 10)) {
+            return {
+                result: 4,
+                line: null
+            };
+        }
+	}
+
+	return rval;
+};
+
+// Add range parameter
+Pickit.pickItems = function (range=Config.PickRange) {
+    var status, item, canFit,
+        needMule = false,
+        pickList = [];
+
+    Town.clearBelt();
+
+    if (me.dead) {
+        return false;
+    }
+
+    while (!me.idle) {
+        delay(40);
+    }
+
+    item = getUnit(4);
+
+    if (item) {
+        do {
+            if ((item.mode === 3 || item.mode === 5) && getDistance(me, item) <= range) {
+                pickList.push(copyUnit(item));
+            }
+        } while (item.getNext());
+    }
+
+    while (pickList.length > 0) {
+        if (me.dead) {
+            return false;
+        }
+
+        pickList.sort(Pickit.sortItems);
+
+        // Check if the item unit is still valid and if it's on ground or being dropped
+        if (copyUnit(pickList[0]).x !== undefined && (pickList[0].mode === 3 || pickList[0].mode === 5) &&
+            (Pather.useTeleport || me.inTown || !checkCollision(me, pickList[0], 0x1))) { // Don't pick items behind walls/obstacles when walking
+            // Check if the item should be picked
+            status = Pickit.checkItem(pickList[0]);
+
+            //  && Item.autoEquipCheck(pickList[0]) pbp
+
+            if (status.result && Pickit.canPick(pickList[0])) {
+                // Override canFit for scrolls, potions and gold
+                canFit = Storage.Inventory.CanFit(pickList[0]) || [4, 22, 76, 77, 78].indexOf(pickList[0].itemType) > -1;
+
+                // Try to make room with FieldID
+                if (!canFit && Config.FieldID && Town.fieldID()) {
+                    canFit = Storage.Inventory.CanFit(pickList[0]) || [4, 22, 76, 77, 78].indexOf(pickList[0].itemType) > -1;
+                }
+
+                // Try to make room by selling items in town
+                if (!canFit) {
+                    // Check if any of the current inventory items can be stashed or need to be identified and eventually sold to make room
+                    if (Pickit.canMakeRoom()) {
+                        print("\xFFc7Trying to make room for " + Pickit.itemColor(pickList[0]) + pickList[0].name);
+
+                        // Go to town and do town chores
+                        if (Town.visitTown()) {
+                            // Recursive check after going to town. We need to remake item list because gids can change.
+                            // Called only if room can be made so it shouldn't error out or block anything.
+
+                            return Pickit.pickItems();
+                        }
+
+                        // Town visit failed - abort
+                        print("\xFFc7Not enough room for " + Pickit.itemColor(pickList[0]) + pickList[0].name);
+
+                        return false;
+                    }
+
+                    // Can't make room - trigger automule
+                    Misc.itemLogger("No room for", pickList[0]);
+                    print("\xFFc7Not enough room for " + Pickit.itemColor(pickList[0]) + pickList[0].name);
+
+                    needMule = true;
+                }
+
+                // Item can fit - pick it up
+                if (canFit) {
+                    Pickit.pickItem(pickList[0], status.result, status.line);
+                }
+            }
+        }
+
+        pickList.shift();
+    }
+
+    // Quit current game and transfer the items to mule
+    if (needMule && AutoMule.getInfo() && AutoMule.getInfo().hasOwnProperty("muleInfo") && AutoMule.getMuleItems().length > 0) {
+        scriptBroadcast("mule");
+        scriptBroadcast("quit");
+    }
+
+    return true;
+};
+
+Pickit.pickItem = function (unit, status, keptLine) {
+	function ItemStats(unit) {
+		this.ilvl = unit.ilvl;
+		this.type = unit.itemType;
+		this.classid = unit.classid;
+		this.name = unit.name;
+		this.color = Pickit.itemColor(unit);
+		this.gold = unit.getStat(14);
+		this.useTk = Config.UseTelekinesis && me.classid === 1 && me.getSkill(43, 1) && (this.type === 4 || this.type === 22 || (this.type > 75 && this.type < 82)) &&
+					getDistance(me, unit) > 5 && getDistance(me, unit) < 20 && !checkCollision(me, unit, 0x4);
+		this.picked = false;
+	}
+
+	var i, item, tick, gid, stats,
+		cancelFlags = [0x01, 0x08, 0x14, 0x0c, 0x19, 0x1a],
+		itemCount = me.itemcount;
+
+	if (unit.gid) {
+		gid = unit.gid;
+		item = getUnit(4, -1, -1, gid);
+	}
+
+	if (!item) {
+		return false;
+	}
+
+	for (i = 0; i < cancelFlags.length; i += 1) {
+		if (getUIFlag(cancelFlags[i])) {
+			delay(500);
+			me.cancel(0);
+
+			break;
+		}
+	}
+
+	stats = new ItemStats(item);
+
+MainLoop:
+	for (i = 0; i < 3; i += 1) {
+		if (!getUnit(4, -1, -1, gid)) {
+			break MainLoop;
+		}
+
+		if (me.dead) {
+			return false;
+		}
+
+		while (!me.idle) {
+			delay(40);
+		}
+
+		if (item.mode !== 3 && item.mode !== 5) {
+			break MainLoop;
+		}
+
+		if (stats.useTk) {
+			Skill.cast(43, 0, item);
+		} else {
+			if (getDistance(me, item) > (i < 1 ? 6 : 4) || checkCollision(me, item, 0x1)) {
+				if (Pather.useTeleport()) {
+					Pather.moveToUnit(item);
+				} else if (!Pather.moveTo(item.x, item.y, 0)) {
+					continue MainLoop;
+				}
+			}
+
+			sendPacket(1, 0x16, 4, 0x4, 4, item.gid, 4, 0);
+		}
+
+		tick = getTickCount();
+
+		while (getTickCount() - tick < 1000) {
+			item = copyUnit(item);
+
+			if (stats.classid === 523) {
+				if (!item.getStat(14) || item.getStat(14) < stats.gold) {
+					print("ÿc7Picked up " + stats.color + (item.getStat(14) ? (item.getStat(14) - stats.gold) : stats.gold) + " " + stats.name);
+
+					return true;
+				}
+			}
+
+			if (item.mode !== 3 && item.mode !== 5) {
+				switch (stats.classid) {
+				case 543: // Key
+					print("ÿc7Picked up " + stats.color + stats.name + " ÿc7(" + Town.checkKeys() + "/12)");
+
+					return true;
+				case 529: // Scroll of Town Portal
+				case 530: // Scroll of Identify
+					print("ÿc7Picked up " + stats.color + stats.name + " ÿc7(" + Town.checkScrolls(stats.classid === 529 ? "tbk" : "ibk") + "/20)");
+
+					return true;
+				}
+
+				break MainLoop;
+			}
+
+			delay(20);
+		}
+
+		// TK failed, disable it
+		stats.useTk = false;
+
+		//print("pick retry");
+	}
+
+	stats.picked = me.itemcount > itemCount || !!me.getItem(-1, -1, gid);
+
+	if (stats.picked) {
+		DataFile.updateStats("lastArea");
+
+		switch (status) {
+		case 1:
+			print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
+
+			if (this.ignoreLog.indexOf(stats.type) === -1) {
+				Misc.itemLogger("Kept", item);
+				Misc.logItem("Kept", item, keptLine);
+			}
+
+			break;
+		case 2:
+			print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Cubing)");
+			Misc.itemLogger("Kept", item, "Cubing " + me.findItems(item.classid).length);
+			Cubing.update();
+
+			break;
+		case 3:
+			print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Runewords)");
+			Misc.itemLogger("Kept", item, "Runewords");
+			Runewords.update(stats.classid, gid);
+
+			break;
+		case 5: // Crafting System
+			print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + ")" + " (Crafting System)");
+			CraftingSystem.update(item);
+
+			break;
+		default:
+			print("ÿc7Picked up " + stats.color + stats.name + " ÿc0(ilvl " + stats.ilvl + (keptLine ? ") (" + keptLine + ")" : ")"));
+
+			break;
+		}
+	}
+
+	return true;
+};

--- a/libs/SoloLeveling/Functions/TownOverrides.js
+++ b/libs/SoloLeveling/Functions/TownOverrides.js
@@ -60,7 +60,6 @@ Town.townTasks = function () {
 	Misc.hireMerc();
 	Misc.equipMerc();
 	this.gamble();
-	this.clearInventory();
 	Town.stash();
 	this.clearJunk();
 	this.organizeStash();
@@ -150,6 +149,9 @@ Town.doChores = function (repair = false) {
 	this.clearScrolls();
 	Town.organizeInventory();
 	this.characterRespec();
+
+	if(me.classid !== 4 && !Precast.checkCTA())	//If not a barb and no CTA, do precast. This is good since townchicken calls doChores. If the char has a cta this is ignored since revive merc does precast
+		Precast.doPrecast(false);
 
 	for (i = 0; i < cancelFlags.length; i += 1) {
 		if (getUIFlag(cancelFlags[i])) {
@@ -915,12 +917,8 @@ Town.clearInventory = function () {
 		) {
 			result = Pickit.checkItem(items[i]).result;
 
-			if (!Item.autoEquipCheck(items[i]) && !NTIP.CheckItem(items[i], NTIP_CheckListNoTier, true).result) {
-				result = 0;
-			}
-
-			if (!Item.autoEquipCheckMerc(items[i]) && !NTIP.CheckItem(items[i], NTIP_CheckListNoTier, true).result) {
-				result = 0;
+			if (!items[i].getFlag(0x10)) {
+				result = -1;
 			}
 
 			switch (result) {
@@ -1241,3 +1239,63 @@ Town.goToTown = function (act, wpmenu) {
 	return true;
 };
 
+Town.reviveMerc = function () {
+	if (!this.needMerc()) {
+		return true;
+	}
+
+	// avoid Aheara
+	if (me.act === 3) {
+		this.goToTown(2);
+	}
+
+	var i, tick, dialog, lines,
+		preArea = me.area,
+		npc = this.initNPC("Merc", "reviveMerc");
+
+	if (!npc) {
+		return false;
+	}
+
+MainLoop:
+	for (i = 0; i < 3; i += 1) {
+		dialog = getDialogLines();
+
+		for (lines = 0; lines < dialog.length; lines += 1) {
+			if (dialog[lines].text.match(":", "gi")) {
+				dialog[lines].handler();
+				delay(Math.max(750, me.ping * 2));
+			}
+
+			// "You do not have enough gold for that."
+			if (dialog[lines].text.match(getLocaleString(3362), "gi")) {
+				return false;
+			}
+		}
+
+		while (getTickCount() - tick < 2000) {
+			if (!!me.getMerc()) {
+				delay(Math.max(750, me.ping * 2));
+
+				break MainLoop;
+			}
+
+			delay(200);
+		}
+	}
+
+	Attack.checkInfinity();
+
+	if (!!me.getMerc()) {
+		if (Config.MercWatch && (me.classid === 4 || Precast.checkCTA())) { // Cast BO on merc so he doesn't just die again. Only Do this is you are a barb or actually have a cta. Otherwise its just a waste of time.
+			print("MercWatch precast");
+			Pather.useWaypoint("random");
+			Precast.doPrecast(true);
+			Pather.useWaypoint(preArea);
+		}
+
+		return true;
+	}
+
+	return false;
+};

--- a/libs/SoloLeveling/Functions/TownOverrides.js
+++ b/libs/SoloLeveling/Functions/TownOverrides.js
@@ -8,6 +8,21 @@ if (!isIncluded("common/Town.js")) {
 	include("common/Town.js");
 }
 
+//Removed Missle Potions for easy gold
+Town.ignoredItemTypes = [ // Items that won't be stashed
+	5, // Arrows
+	6, // Bolts
+	18, // Book (Tome)
+	22, // Scroll
+	41, // Key
+	76, // Healing Potion
+	77, // Mana Potion
+	78, // Rejuvenation Potion
+	79, // Stamina Potion
+	80, // Antidote Potion
+	81 // Thawing Potion
+];
+
 Town.townTasks = function () {
 	if (!me.inTown) {
 		Town.goToTown();


### PR DESCRIPTION
-Pickit overrides allow the tiers to be displayed on items in the item viewer tab.
-MuleloggerOverrides allows users to see their currently equipped items in the char viewer tab
-Precast fix for mercs to avoid wasting time
-Add mfrating to tiercalculator for when bot is lower than 50mf