### PR TITLE
Moved seal undefined check before property read

### DIFF
--- a/libs/SoloLeveling/Scripts/diablo.js
+++ b/libs/SoloLeveling/Scripts/diablo.js
@@ -211,7 +211,7 @@ function diablo () {
 				}
 			}
 
-			if (seal.mode || seal === undefined) {
+			if (seal === undefined || seal.mode) {
 				return true;
 			}
 


### PR DESCRIPTION
I've simply moved the undefined check on seal to before the attempt to read the 'mode' property. This was causing repeated errors on one of my characters, preventing progress past the Diablo fight.