### PR TITLE
Update radament.js

### DIFF
--- a/libs/SoloLeveling/Scripts/radament.js
+++ b/libs/SoloLeveling/Scripts/radament.js
@@ -10,6 +10,8 @@ function radament () {
 	me.overhead("radament");
 
 	if (!Pather.checkWP(48)) {
+		Pather.moveTo(5222, 5180);
+		Pather.useUnit(5, 20, 47);
 		Pather.getWP(48);
 	} else {
 		Pather.useWaypoint(48);


### PR DESCRIPTION
Take the lower Sewers Level 1 entrance because the Level 2 stairs are always 
closer to this one than the upper trapdoor entrance near Greiz.