### PR TITLE
Update buildFiles

### DIFF
--- a/libs/SoloLeveling/BuildFiles/druid.ElementalBuild.js
+++ b/libs/SoloLeveling/BuildFiles/druid.ElementalBuild.js
@@ -13,7 +13,7 @@ var build = {
 	mercAuraWanted: 108,
 	mercDiff: 0,
 	stats: [
-		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["vitality", "all"]
+		["dexterity", 35], ["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["vitality", "all"]
 	],
 	skills: [
 		[225, 2, false], // fire storm 3

--- a/libs/SoloLeveling/BuildFiles/druid.WindBuild.js
+++ b/libs/SoloLeveling/BuildFiles/druid.WindBuild.js
@@ -13,7 +13,7 @@ var build = {
 	mercAuraWanted: 108,
 	mercDiff: 0,
 	stats: [
-		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["vitality", "all"]
+		["dexterity", 35], ["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["vitality", "all"]
 	],
 	skills: [
 		[221, 1, false], //Raven

--- a/libs/SoloLeveling/BuildFiles/sorceress.BlizzballerBuild.js
+++ b/libs/SoloLeveling/BuildFiles/sorceress.BlizzballerBuild.js
@@ -13,7 +13,7 @@ var build = {
 	mercAuraWanted: 114,
 	mercDiff: 1,
 	stats: [
-		["energy", 50], ["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 84], ["dexterity", "block"], ["vitality", "all"]
+		["energy", 50], ["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["dexterity", "block"], ["vitality", "all"]
 	],
 	skills: [
 		[36, 1], // Fire Bolt

--- a/libs/SoloLeveling/BuildFiles/sorceress.ColdBuild.js
+++ b/libs/SoloLeveling/BuildFiles/sorceress.ColdBuild.js
@@ -13,7 +13,7 @@ var build = {
 	mercAuraWanted: 114,
 	mercDiff: 1,
 	stats: [
-		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 84], ["dexterity", "block"], ["vitality", "all"]
+		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["dexterity", "block"], ["vitality", "all"]
 	],
 	skills: [
 		[37, 1], // warmth

--- a/libs/SoloLeveling/BuildFiles/sorceress.MeteorbBuild.js
+++ b/libs/SoloLeveling/BuildFiles/sorceress.MeteorbBuild.js
@@ -13,7 +13,7 @@ var build = {
 	mercAuraWanted: 114,
 	mercDiff: 1,
 	stats: [
-		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 84], ["dexterity", "block"], ["vitality", "all"]
+		["strength", 48], ["vitality", 165], ["strength", 61], ["vitality", 252], ["strength", 156], ["dexterity", "block"], ["vitality", "all"]
 	],
 	skills: [
 		[36, 1], // Fire Bolt


### PR DESCRIPTION
- Cold, Blizzballer, and Meteorb needed more strength to be able to equip spirit on switch
- Elemental and Wind builds needed more dex to equip hoto